### PR TITLE
Send PNG files encoded as PNG data

### DIFF
--- a/cmd/icat/icat.go
+++ b/cmd/icat/icat.go
@@ -75,7 +75,7 @@ func _main() error {
 func transcode(r io.Reader, w io.Writer) error {
 	var buf bytes.Buffer
 	in := io.TeeReader(r, &buf)
-	_, format, err := image.DecodeConfig(in)
+	cfg, format, err := image.DecodeConfig(in)
 	if err != nil {
 		return readError(r, err)
 	}
@@ -85,7 +85,7 @@ func transcode(r io.Reader, w io.Writer) error {
 	// For PNG we send the raw file that probably has better compression
 	// https://sw.kovidgoyal.net/kitty/graphics-protocol/#png-data
 	if format == "png" {
-		if _, err = io.WriteString(w, "\033_Gq=1,a=T,f=100,"); err != nil {
+		if _, err = fmt.Fprintf(w, "\033_Gq=1,a=T,f=100,s=%d,v=%d,", cfg.Width, cfg.Height); err != nil {
 			return err
 		}
 

--- a/cmd/icat/icat.go
+++ b/cmd/icat/icat.go
@@ -73,7 +73,7 @@ func _main() error {
 	return nil
 }
 
-var pngHeader = [8]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+var pngHeader = [8]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n'}
 
 func transcode(r io.Reader, w io.Writer) error {
 	in := bufio.NewReader(r)

--- a/cmd/icat/icat.go
+++ b/cmd/icat/icat.go
@@ -19,10 +19,7 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"image"
-	"io"
 	"os"
 
 	_ "image/gif"
@@ -32,7 +29,6 @@ import (
 	"golang.org/x/term"
 
 	"github.com/dolmen-go/kittyimg"
-	"github.com/dolmen-go/kittyimg/internal/writers"
 )
 
 func main() {
@@ -46,7 +42,7 @@ func main() {
 
 func _main() error {
 	if (len(os.Args) == 1 || os.Args[1] == "-") && !term.IsTerminal(int(os.Stdin.Fd())) {
-		if err := transcode(os.Stdin, os.Stdout); err != nil {
+		if err := kittyimg.Transcode(os.Stdout, os.Stdin); err != nil {
 			return err
 		}
 		os.Stdout.WriteString("\n")
@@ -61,7 +57,7 @@ func _main() error {
 			}
 			defer f.Close()
 
-			return transcode(f, os.Stdout)
+			return kittyimg.Transcode(os.Stdout, f)
 		})(file)
 		if err != nil {
 			return err
@@ -70,72 +66,4 @@ func _main() error {
 	}
 
 	return nil
-}
-
-func transcode(r io.Reader, w io.Writer) error {
-	var buf bytes.Buffer
-	in := io.TeeReader(r, &buf)
-	cfg, format, err := image.DecodeConfig(in)
-	if err != nil {
-		return readError(r, err)
-	}
-	// Restart from byte 0
-	in = io.MultiReader(&buf, r)
-
-	// For PNG we send the raw file that probably has better compression
-	// https://sw.kovidgoyal.net/kitty/graphics-protocol/#png-data
-	if format == "png" {
-		if _, err = fmt.Fprintf(w, "\033_Gq=1,a=T,f=100,s=%d,v=%d,", cfg.Width, cfg.Height); err != nil {
-			return err
-		}
-
-		var pw writers.PayloadWriter
-		pw.Reset(w)
-
-		if _, err = io.Copy(&pw, in); err != nil {
-			return err
-		}
-		return pw.Close()
-	}
-
-	img, _, err := image.Decode(in)
-	if err != nil {
-		return readError(r, err)
-	}
-	// return icat(w, img)
-	return kittyimg.Fprint(w, img)
-}
-
-func readError(r io.Reader, err error) error {
-	if r, ok := r.(interface{ Name() string }); ok {
-		if name := r.Name(); name != "" {
-			return fmt.Errorf("%s: %w", r.Name(), err)
-		}
-	}
-	return err
-}
-
-func icat(w io.Writer, img image.Image) error {
-	bounds := img.Bounds()
-
-	// f=32 => RGBA
-	_, err := fmt.Fprintf(w, "\033_Gq=1,a=T,f=32,s=%d,v=%d,t=d,", bounds.Dx(), bounds.Dy())
-	if err != nil {
-		return err
-	}
-
-	var zw writers.PayloadWriter
-	zw.Reset(w)
-
-	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-		for x := bounds.Min.X; x < bounds.Max.X; x++ {
-			r, g, b, a := img.At(x, y).RGBA()
-			// A color's RGBA method returns values in the range [0, 65535].
-			// Shifting by 8 reduces this to the range [0, 255].
-			if _, err = zw.Write([]byte{byte(r >> 8), byte(g >> 8), byte(b >> 8), byte(a >> 8)}); err != nil {
-				return err
-			}
-		}
-	}
-	return zw.Close()
 }


### PR DESCRIPTION
The Kitty graphics protocol has builtin support for sending images as PNG: https://sw.kovidgoyal.net/kitty/graphics-protocol/#png-data

Let's send PNG files directly as is instead of decoding each pixel.

Benefits:
* smaller payload: the PNG encoding result is smaller than the general RGBA encoding. PNG also has multiple compression layers, such as indexed palette.
* avoid decoding PNG, and let the terminal directly handle it by just passing the file content without looking into it. Less CPU/memory usage on our side

This implementation extends the `kittyimg` package API with a new [`func Transcode(io.Writer, io.Reader) error`](https://pkg.go.dev/github.com/dolmen-go/kittyimg#Transcode) that takes a graphic file as input and writes the Kitty direct stream representation.